### PR TITLE
Refactor main layout

### DIFF
--- a/src/app/appointment/confirm/page.tsx
+++ b/src/app/appointment/confirm/page.tsx
@@ -11,11 +11,11 @@ export default function Page({
 }: {
   searchParams: { [key: string]: string | string[] | undefined };
 }) {
-  const queryString = window.location.search;
-  const params = new URLSearchParams(queryString);
-  const appointmentId = params.get('id');
-
   useEffect(() => {
+    const queryString = window.location.search;
+    const params = new URLSearchParams(queryString);
+    const appointmentId = params.get('id');
+
     const confirmAppointment = async () => {
       if (appointmentId) {
         const res = await ScheduleService.confirm(appointmentId);

--- a/src/app/components/layout/App.tsx
+++ b/src/app/components/layout/App.tsx
@@ -7,7 +7,6 @@ import { ModalBackground } from 'designSystem/Modals/Modal';
 import Head from 'next/head';
 
 import { Breakpoint } from './Breakpoint';
-import MainLayout from './MainLayout';
 
 export default function Html({ children }: { children: ReactNode }) {
   const { isModalOpen, setIsModalOpen, isMainScrollEnabled } = useGlobalStore(
@@ -37,7 +36,7 @@ export default function Html({ children }: { children: ReactNode }) {
           }}
         />
         <Breakpoint />
-        <MainLayout>{children}</MainLayout>
+        {children}
       </body>
     </html>
   );

--- a/src/app/components/layout/DashboardLayout.tsx
+++ b/src/app/components/layout/DashboardLayout.tsx
@@ -1,0 +1,56 @@
+import { ClinicProfessional } from '@components/ClinicProfessional';
+import ButtonMessage from '@components/ui/ButtonMessage';
+import { Button } from 'designSystem/Buttons/Buttons';
+import { Container, Flex } from 'designSystem/Layouts/Layouts';
+import { SvgArrowSmallLeft } from 'icons/Icons';
+
+export default function DashboardLayout({
+  hideTopBar = false,
+  hideBackButton = false,
+  hideContactButtons = false,
+  hideProfessionalSelector = false,
+  children,
+}: {
+  hideTopBar?: boolean;
+  hideBackButton?: boolean;
+  hideContactButtons?: boolean;
+  hideProfessionalSelector?: boolean;
+  children: React.ReactNode;
+}) {
+  return (
+    <main className="min-h-screen h-100 pt-4 text-sm bg-[url('/images/dashboard/background/main_background.png')] bg-[#A96FE7] bg-bottom bg-contain bg-no-repeat">
+      <Flex
+        layout="col-center"
+        className="min-h-screen h-100 text-hg-black text-sm overflow-hidden"
+      >
+        {!hideTopBar && (
+          <Container>
+            <Flex layout="row-left" className="w-full pb-8">
+              {!hideBackButton && (
+                <Button href="#" type="tertiary">
+                  <Flex layout="row-left">
+                    <SvgArrowSmallLeft
+                      height={40}
+                      width={40}
+                      className="pr-2"
+                    />
+                    Volver
+                  </Flex>
+                </Button>
+              )}
+
+              {!hideContactButtons && <ButtonMessage />}
+
+              {!hideProfessionalSelector && (
+                <div className="ml-auto z-10">
+                  <ClinicProfessional />
+                </div>
+              )}
+            </Flex>
+          </Container>
+        )}
+        {children}
+      </Flex>
+    </main>
+  );
+}

--- a/src/app/components/layout/MainLayout.tsx
+++ b/src/app/components/layout/MainLayout.tsx
@@ -2,31 +2,29 @@
 
 import { useEffect, useState } from 'react';
 import { useGlobalPersistedStore } from 'app/stores/globalStore';
-import { usePathname } from 'next/navigation';
 
 import { DeviceSize } from './Breakpoint';
+import DashboardLayout from './DashboardLayout';
 import { Footer } from './Footer';
 import Header from './Header';
 
-const HIDE_WEBHEADER_PATHS = ['/user/budget', '/user/passport', '/form'];
-const HIDE_WEBHEADER_PATTERNS = ['/dashboard', '/appointment'];
-
-const hideHeader = (path: string) => {
-  return HIDE_WEBHEADER_PATHS.includes(path);
-};
-
-const isDashboard = (path: string) => {
-  return HIDE_WEBHEADER_PATTERNS.some(item => path.startsWith(item));
-};
-
 export default function MainLayout({
+  isDashboard = false,
+  hideTopBar = false,
+  hideBackButton = false,
+  hideContactButtons = false,
+  hideProfessionalSelector = false,
   children,
 }: {
+  isDashboard?: boolean;
+  hideBackButton?: boolean;
+  hideTopBar?: boolean;
+  hideContactButtons?: boolean;
+  hideProfessionalSelector?: boolean;
   children: React.ReactNode;
 }) {
   const [isHydrated, setISHydrated] = useState(false);
   const setDeviceSize = useGlobalPersistedStore(state => state.setDeviceSize);
-  const pathname = usePathname();
 
   useEffect(() => {
     setDeviceSize(DeviceSize());
@@ -39,9 +37,22 @@ export default function MainLayout({
 
   return (
     <>
-      {hideHeader(pathname) || (!isDashboard(pathname) && <Header />)}
-      {children}
-      {hideHeader(pathname) || (!isDashboard(pathname) && <Footer />)}
+      {isDashboard ? (
+        <DashboardLayout
+          hideTopBar={hideTopBar}
+          hideBackButton={hideBackButton}
+          hideContactButtons={hideContactButtons}
+          hideProfessionalSelector={hideProfessionalSelector}
+        >
+          {children}
+        </DashboardLayout>
+      ) : (
+        <>
+          <Header />
+          {children}
+          <Footer />
+        </>
+      )}
     </>
   );
 }

--- a/src/app/dashboard/(pages)/budgets/HightLightedProduct/HightLightedProduct.tsx
+++ b/src/app/dashboard/(pages)/budgets/HightLightedProduct/HightLightedProduct.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import Bugsnag from '@bugsnag/js';
 import { CartItem, emptyProduct } from '@interface/product';
 import ProductService from '@services/ProductService';
+import { useGlobalStore } from 'app/stores/globalStore';
 import { HOLAGLOW_COLORS } from 'app/utils/colors';
 import { Carousel } from 'designSystem/Carousel/Carousel';
 import { Flex } from 'designSystem/Layouts/Layouts';
@@ -16,6 +17,8 @@ import { Operation, Quantifier } from './Quantifier';
 const DEFAULT_IMG_SRC = '/images/product/holaglowProduct.png?1';
 
 export default function HightLightedProduct() {
+  const setIsModalOpen = useGlobalStore(state => state.setIsModalOpen);
+
   const addToCart = useCartStore(state => state.addItemToCart);
   const getQuantityOfProduct = useCartStore(
     state => state.getQuantityOfProduct
@@ -83,7 +86,10 @@ export default function HightLightedProduct() {
             height={30}
             width={30}
             className=""
-            onClick={() => setHighlightProduct(emptyProduct)}
+            onClick={() => {
+              setHighlightProduct(emptyProduct);
+              setIsModalOpen(false);
+            }}
           />
         </Flex>
         <Flex layout="row-left" className="w-full gap-4 items-stretch mb-4">

--- a/src/app/dashboard/(pages)/budgets/page.tsx
+++ b/src/app/dashboard/(pages)/budgets/page.tsx
@@ -5,6 +5,7 @@ import { Filters } from '@components/Filters';
 import { emptyProduct, Product } from '@interface/product';
 import ProductService from '@services/ProductService';
 import { normalizeString } from '@utils/validators';
+import MainLayout from 'app/components/layout/MainLayout';
 import { HOLAGLOW_COLORS } from 'app/utils/colors';
 import { Container, Flex } from 'designSystem/Layouts/Layouts';
 import { Modal, ModalBackground } from 'designSystem/Modals/Modal';
@@ -208,11 +209,7 @@ export default function Page() {
   } else {
     const filteredProducts = filterProducts() || [];
     return (
-      <CheckHydration>
-        <ModalBackground
-          isVisible={showProductModal}
-          onClick={() => setHighlightProduct(emptyProduct)}
-        ></ModalBackground>
+      <MainLayout isDashboard>
         <Modal isVisible={showProductModal} width="w-3/4">
           <HightLightedProduct />
         </Modal>
@@ -243,7 +240,7 @@ export default function Page() {
             </div>
           )}
         </Flex>
-      </CheckHydration>
+      </MainLayout>
     );
   }
 }

--- a/src/app/dashboard/(pages)/budgets/treatments/ProductCard.tsx
+++ b/src/app/dashboard/(pages)/budgets/treatments/ProductCard.tsx
@@ -49,10 +49,12 @@ export default function ProductCard({ product, isCheckout, budget }: Props) {
         ${!isCheckout && 'cursor-pointer'}`}
       onClick={() => {
         setHighlightProduct(product);
-        setIsModalOpen(true);
+        if (!isCheckout) {
+          setIsModalOpen(true);
+        }
       }}
     >
-      {!budget ? (
+      {!budget && (
         <SvgClose
           width={30}
           height={30}
@@ -60,8 +62,6 @@ export default function ProductCard({ product, isCheckout, budget }: Props) {
           className="absolute top-2 right-2 cursor-pointer"
           onClick={() => removeFromCart(product)}
         />
-      ) : (
-        <></>
       )}
       <div
         className={`aspect-square relative ${

--- a/src/app/dashboard/(pages)/budgets/treatments/ProductCard.tsx
+++ b/src/app/dashboard/(pages)/budgets/treatments/ProductCard.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import { CartItem } from '@interface/product';
+import { useGlobalStore } from 'app/stores/globalStore';
 import { HOLAGLOW_COLORS } from 'app/utils/colors';
 import { Button } from 'designSystem/Buttons/Buttons';
 import { Flex } from 'designSystem/Layouts/Layouts';
@@ -25,7 +26,7 @@ export default function ProductCard({ product, isCheckout, budget }: Props) {
   const removeFromCart = useCartStore(state => state.removeFromCart);
   const addToCart = useCartStore(state => state.addItemToCart);
   const setHighlightProduct = useCartStore(state => state.setHighlightProduct);
-  const applyItemDiscount = useCartStore(state => state.applyItemDiscount);
+  const setIsModalOpen = useGlobalStore(state => state.setIsModalOpen);
   const removeItemDiscount = useCartStore(state => state.removeItemDiscount);
 
   const [showDiscountForm, setShowDiscountBlock] = useState(false);
@@ -46,7 +47,10 @@ export default function ProductCard({ product, isCheckout, budget }: Props) {
       className={`
         border border-hg-darkMalva bg-white text-hg-darkMalva rounded-lg overflow-hidden relative
         ${!isCheckout && 'cursor-pointer'}`}
-      onClick={() => setHighlightProduct(product)}
+      onClick={() => {
+        setHighlightProduct(product);
+        setIsModalOpen(true);
+      }}
     >
       {!budget ? (
         <SvgClose

--- a/src/app/dashboard/(pages)/checkout/page.tsx
+++ b/src/app/dashboard/(pages)/checkout/page.tsx
@@ -7,13 +7,13 @@ import { INITIAL_STATE_PAYMENT } from '@interface/paymentList';
 import { budgetService } from '@services/BudgetService';
 import { INITIAL_STATE } from '@utils/constants';
 import { ERROR_POST } from '@utils/textConstants';
+import MainLayout from 'app/components/layout/MainLayout';
 import { PaymentModule } from 'app/dashboard/(pages)/checkout/components/payment/Payments';
 import { Button } from 'designSystem/Buttons/Buttons';
 import { Container, Flex } from 'designSystem/Layouts/Layouts';
 import { Title } from 'designSystem/Texts/Texts';
 import { SvgAngleDown, SvgSpinner } from 'icons/Icons';
 import { useRouter } from 'next/navigation';
-import CheckHydration from 'utils/CheckHydration';
 
 import { CartTotal } from '../budgets/minicart/Cart';
 import { useCartStore } from '../budgets/stores/userCartStore';
@@ -88,7 +88,7 @@ const Page = () => {
     router.push('/dashboard/menu');
   }
   return (
-    <CheckHydration>
+    <MainLayout isDashboard>
       <Container>
         <Title size="2xl" className="text-left mb-4">
           Resumen
@@ -165,7 +165,7 @@ const Page = () => {
           </Flex>
         </Flex>
       </Container>
-    </CheckHydration>
+    </MainLayout>
   );
 };
 

--- a/src/app/dashboard/(pages)/menu/page.tsx
+++ b/src/app/dashboard/(pages)/menu/page.tsx
@@ -3,6 +3,7 @@
 import React, { useEffect, useState } from 'react';
 import ScheduleService from '@services/ScheduleService';
 import { clearLocalStorage } from '@utils/utils';
+import MainLayout from 'app/components/layout/MainLayout';
 import { Button } from 'designSystem/Buttons/Buttons';
 import { Container, Flex } from 'designSystem/Layouts/Layouts';
 import { useRouter } from 'next/navigation';
@@ -11,7 +12,6 @@ import DashboardMenuItem from './DashboardMenuItem';
 import { menuItems } from './MenuItems';
 
 const Page = () => {
-  menuItems;
   const [username, setUserName] = useState('');
   const [clinicId, setClinicId] = useState<string | null>(null);
   const [boxId, setBoxId] = useState<string | null>(null);
@@ -56,7 +56,7 @@ const Page = () => {
     }
   };
   return (
-    <>
+    <MainLayout isDashboard hideTopBar>
       {username && (
         <Container>
           <Flex layout="col-center">
@@ -114,7 +114,7 @@ const Page = () => {
           )}
         </Container>
       )}
-    </>
+    </MainLayout>
   );
 };
 export default Page;

--- a/src/app/dashboard/components/Filters.tsx
+++ b/src/app/dashboard/components/Filters.tsx
@@ -24,12 +24,12 @@ export const Filters: React.FC<FilterPageProps> = ({ onClickFilter }) => {
   return (
     <Flex
       layout="col-left"
-      className={`sticky shrink-0 top-[10px] transition-all pr-8 mr-8 border-r border-hg-lightMalva`}
+      className={`sticky shrink-0 top-[10px] transition-all pr-8 mr-8 border-r border-white/50`}
     >
       <SvgDoubleAngleLeft
-        height={40}
-        width={40}
-        className={`absolute top-0 -right-[19px] bg-hg-lime text-hg-darkMalva rounded-full p-2 cursor-pointer transition-all ${
+        height={34}
+        width={34}
+        className={`absolute top-0 -right-[17px] bg-hg-lime text-hg-darkMalva rounded-full p-1 cursor-pointer transition-all ${
           showFilters ? 'rotate-0' : 'rotate-180'
         }`}
         onClick={() => setShowFilters(!showFilters)}
@@ -38,7 +38,7 @@ export const Filters: React.FC<FilterPageProps> = ({ onClickFilter }) => {
 
       <div
         className={`transition-all overflow-hidden ${
-          showFilters ? 'w-[260px]' : 'w-0'
+          showFilters ? 'w-[225px]' : 'w-0'
         }`}
       >
         <input

--- a/src/app/dashboard/old_layout.tsx
+++ b/src/app/dashboard/old_layout.tsx
@@ -29,7 +29,7 @@ export default function DashboardLayout({
     '/dashboard/menu',
   ];
   return (
-    <main className="min-h-screen h-100 text-sm bg-[url('/images/dashboard/background/main_background.png')] bg-[#A96FE7] bg-bottom bg-center bg-contain bg-no-repeat">
+    <main className="min-h-screen h-100 text-sm bg-[url('/images/dashboard/background/main_background.png')] bg-[#A96FE7] bg-bottom bg-contain bg-no-repeat">
       <Flex
         layout="col-center"
         className="min-h-screen h-100 text-hg-black text-sm overflow-hidden"

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -9,6 +9,7 @@ import * as config from '@utils/textConstants';
 import { ERROR_GETTING_DATA } from '@utils/textConstants';
 import { clearLocalStorage } from '@utils/utils';
 import * as utils from '@utils/validators';
+import MainLayout from 'app/components/layout/MainLayout';
 import { useRouter } from 'next/navigation';
 
 import RegistrationForm from './RegistrationForm';
@@ -192,24 +193,31 @@ export default function Page({
   };
 
   return (
-    <div className="mt-8">
-      {showRegistration ? (
-        <RegistrationForm
-          formData={formData}
-          handleFieldChange={handleFormFieldChange}
-          handleContinue={handleContinue}
-          errors={errors}
-          isLoading={isLoading}
-        />
-      ) : (
-        <SearchUser
-          email={userEmail}
-          handleFieldChange={handleFieldEmailChange}
-          handleCheckUser={handleCheckUser}
-          errors={errors}
-          isLoading={isLoading}
-        />
-      )}
-    </div>
+    <MainLayout
+      isDashboard
+      hideBackButton
+      hideContactButtons
+      hideProfessionalSelector
+    >
+      <div className="mt-8">
+        {showRegistration ? (
+          <RegistrationForm
+            formData={formData}
+            handleFieldChange={handleFormFieldChange}
+            handleContinue={handleContinue}
+            errors={errors}
+            isLoading={isLoading}
+          />
+        ) : (
+          <SearchUser
+            email={userEmail}
+            handleFieldChange={handleFieldEmailChange}
+            handleCheckUser={handleCheckUser}
+            errors={errors}
+            isLoading={isLoading}
+          />
+        )}
+      </div>
+    </MainLayout>
   );
 }

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -25,11 +25,7 @@ export default function Page({
   const [errors, setErrors] = useState<Array<string>>([]);
   const [showRegistration, setShowRegistration] = useState(false);
   const [userEmail, setUserEmail] = useState('');
-
-  const queryString = window.location.search;
-  const params = new URLSearchParams(queryString);
-  const clinicId = params.get('clinicId');
-  const boxId = params.get('boxId');
+  const [boxId, setBoxId] = useState('');
 
   const [formData, setFormData] = useState<Client>({
     email: '',
@@ -57,6 +53,10 @@ export default function Page({
 
   useEffect(() => {
     clearLocalStorage(false);
+
+    const queryString = window.location.search;
+    const params = new URLSearchParams(queryString);
+    setBoxId(params.get('boxId') || '');
   }, []);
 
   const handleCheckUser = async () => {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,10 +7,11 @@ import Professionals from './components/home/Professionals';
 import Testimonials from './components/home/Testimonials';
 import ValuesCarousel from './components/home/ValuesCarousel';
 import ValuesDescription from './components/home/ValuesDescription';
+import MainLayout from './components/layout/MainLayout';
 
 export default function Home() {
   return (
-    <>
+    <MainLayout>
       <Hero />
       <ValuesCarousel />
       <ValuesDescription />
@@ -20,6 +21,6 @@ export default function Home() {
       <InTheNews />
       <Clinics />
       <GoToTreatments />
-    </>
+    </MainLayout>
   );
 }

--- a/src/designSystem/Buttons/Buttons.tsx
+++ b/src/designSystem/Buttons/Buttons.tsx
@@ -47,7 +47,7 @@ export const Button = ({
   return (
     <button
       className={twMerge(
-        `transition-all relative group overflow-visible -top-[2px] ${className}`
+        `transition-all relative group overflow-visible top-[3px] ${className}`
       )}
       onClick={onClick}
       type={rest?.isSubmit ? 'submit' : 'button'}


### PR DESCRIPTION
Se ha refactorizado el <MainLayout> para separar lógica de visualización entre la web y el dashboard:

web: <MainLayout>
https://holaglowreact-git-refactormainlayout-hola-glow.vercel.app/

dashboard: <MainLayout isDashboard>
https://holaglowreact-git-refactormainlayout-hola-glow.vercel.app/dashboard

El MainLayout tiene parámetros opcionales para esconder elementos del header del dashboard:
-   hideTopBar?: boolean;
-   hideBackButton?: boolean;
-   hideContactButtons?: boolean;
-   hideProfessionalSelector?: boolean;
